### PR TITLE
TX Port Mon Feature Implemented

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -56,7 +56,8 @@ orchagent_SOURCES = \
             sfloworch.cpp \
             chassisorch.cpp \
             debugcounterorch.cpp \
-            natorch.cpp
+            natorch.cpp \
+            txportmonorch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -36,6 +36,7 @@ BufferOrch *gBufferOrch;
 SwitchOrch *gSwitchOrch;
 Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
+TxPortMonOrch *gTxPortMonOrch;
 
 bool gIsNatSupported = false;
 
@@ -219,6 +220,10 @@ bool OrchDaemon::init()
 
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);
 
+    TableConnector stateDbTxErr(m_stateDb, /*"TX_ERR_STATE"*/ TXPORTMONORCH_STATE_TX_ERROR_TABLE);
+    TableConnector confDbTxErr(m_configDb, /*"TX_ERR_CFG"*/TXPORTMONORCH_CFG_TX_ERROR_TABLE);
+    gTxPortMonOrch = new TxPortMonOrch(confDbTxErr, stateDbTxErr);
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -227,7 +232,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch, policer_orch, sflow_orch, debug_counter_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch, policer_orch, sflow_orch, debug_counter_orch, gTxPortMonOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -31,6 +31,7 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "natorch.h"
+#include "txportmonorch.h"
 
 using namespace swss;
 

--- a/orchagent/txportmonorch.cpp
+++ b/orchagent/txportmonorch.cpp
@@ -1,0 +1,404 @@
+#include "txportmonorch.h"
+
+extern sai_port_api_t *sai_port_api;
+extern PortsOrch*       gPortsOrch;
+
+#define TXSTATE_OK 0
+#define TXSTATE_ERR 1
+
+#define SWSS_LOG_CRITICAL(MSG, ...)       swss::Logger::getInstance().write(swss::Logger::SWSS_CRIT,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
+
+std::string TxStatusName[] = {"OK", "ERROR"};
+
+const std::string currentDateTime() {
+    time_t     now = time(0);
+    struct tm  tstruct;
+    char       buf[80];
+    tstruct = *localtime(&now);
+    // Visit http://en.cppreference.com/w/cpp/chrono/c/strftime
+    // for more information about date/time format
+    strftime(buf, sizeof(buf), "%Y-%m-%d.%X", &tstruct);
+    return buf;
+}
+
+TxPortMonOrch::~TxPortMonOrch(){
+
+}
+
+TxPortMonOrch::TxPortMonOrch(TableConnector confDbConnector,
+		TableConnector stateDbConnector) :
+		Orch(confDbConnector.first, confDbConnector.second),
+		m_pollPeriod(0)
+{
+
+
+        m_countersDb = make_shared<DBConnector>("COUNTERS_DB", 0);
+
+		SWSS_LOG_ENTER();
+
+		swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_INFO);
+
+
+		m_stateTxErrorTable = make_shared<Table>(stateDbConnector.first, stateDbConnector.second);
+		m_countersTable = make_shared<Table>(m_countersDb.get(), TXPORTMONORCH_COUNTERTABLE);
+
+
+		/* Create an Executor with a Configurable PollTimer */
+		m_pollTimer = new SelectableTimer(timespec { .tv_sec = 0, .tv_nsec = 0 });
+		Orch::addExecutor(new ExecutableTimer(m_pollTimer, this, TXPORTMONORCH_SEL_TIMER));
+
+
+		SWSS_LOG_NOTICE("TxMonPortOrch initialized with table %s %s\n",
+		                    stateDbConnector.second.c_str(),
+		                    confDbConnector.second.c_str());
+}
+
+void TxPortMonOrch::startTimer(uint32_t interval)
+{
+    SWSS_LOG_ENTER();
+
+    try
+    {
+        auto interv = timespec { .tv_sec = interval, .tv_nsec = 0 };
+
+        SWSS_LOG_INFO("TxMonPortOrch: startTimer,  find executor %p\n", m_pollTimer);
+        m_pollTimer->setInterval(interv);
+        m_pollTimer->stop();
+        m_pollTimer->start();
+        m_pollPeriod = interval;
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("TxMonPortOrch: Failed to start timer\n");
+    }
+}
+
+void TxPortMonOrch::doTask(SelectableTimer &timer){
+	 SWSS_LOG_INFO("TxMonOrch: doTask invoked with timer update\n");
+	 this->pollErrorStatistics();
+}
+
+/* Pools error stats from counter db for a port and updates the state accordingly */
+int TxPortMonOrch::pollOnePortErrorStatistics(const string &port, TxErrorStats &stat){
+
+    if (txPortState(stat) == TXSTATE_ERR){
+        SWSS_LOG_CRITICAL("TxPortMonOrch Port %s (%s) already in ERROR State and will stay until polling feature is disabled",port.c_str(), sai_serialize_object_id(txPortId(stat)).c_str());
+        return 0;
+    }
+
+	if (m_TxErrorTable.find(port) == m_TxErrorTable.end()){
+		SWSS_LOG_NOTICE("TxPortMonOrch::pollOnePortErrorStatistics: Local map should have been be pre-populated before polling current statistics");
+		return 0;
+	}
+
+	uint64_t prevCount = txPortErrCount(stat);
+	uint64_t currCount;
+
+	if (this->fetchTxErrorStats(port, currCount, txPortId(stat))){
+		SWSS_LOG_ERROR("TxPortMonOrch::pollOnePortErrorStatistics fetching error count from CounterDB failed for port %s", port.c_str());
+		return -1;
+	}
+
+	// TODO: Keep Track of last updated time and also use that info for judging if the port actually went to an error state
+	if (currCount - prevCount >= txPortThreshold(stat)){
+		txPortState(stat) = static_cast<int8_t>(TXSTATE_ERR);
+		SWSS_LOG_CRITICAL("TxError Threshold on Port %s (%s) crossed %ld in the last %d secs as of %s an status is set to ERROR",
+		                      port.c_str(), sai_serialize_object_id(txPortId(stat)).c_str(), (unsigned long)txPortThreshold(stat), (int)m_pollPeriod, currentDateTime().c_str());
+	}
+
+	SWSS_LOG_INFO("TxPortMonOrch::pollOnePortErrorStatistics last Port update: %s (%s), State: %s, Error Count in Last Poll Period: %ld", port.c_str(),
+	                  sai_serialize_object_id(txPortId(stat)).c_str(), TxStatusName[txPortState(stat)].c_str(), currCount - prevCount);
+
+	txPortErrCount(stat) = currCount;
+
+	this->writeToStateDb(port);
+
+	return 0;
+}
+
+
+void TxPortMonOrch::pollErrorStatistics(){
+
+    if (m_pollPeriod == 0){
+        SWSS_LOG_INFO("TxPortMonOrch: pollperiod has to be set in order to retrieve statistics");
+        return ;
+    }
+
+	SWSS_LOG_ENTER();
+
+	KeyOpFieldsValuesTuple portEntry;
+
+	for (auto& entry : m_TxErrorTable){
+
+		std::vector<FieldValueTuple> fields;
+		int rc;
+
+		SWSS_LOG_INFO("TxPortMonOrch::pollErrorStatistics:Port %s BEFORE-POLL tx_error_stat %ld \n", entry.first.c_str(),
+		                        txPortErrCount(entry.second));
+
+		rc = this->pollOnePortErrorStatistics(entry.first, entry.second);
+		if (rc != 0)
+			SWSS_LOG_ERROR("TxPortMonOrch::pollErrorStatistics: port %s tx_error_stat failed %d\n", entry.first.c_str(), rc);
+
+		SWSS_LOG_INFO("TxPortMonOrch::pollErrorStatistics:Port %s AFTER-POLL tx_error_stat %ld \n", entry.first.c_str(),
+				                        txPortErrCount(entry.second));
+
+	}
+
+	SWSS_LOG_INFO("TxPortMonOrch::pollErrorStatistics Polling completed for all ports");
+}
+
+
+/* Handle Configuration Update */
+/* Can include either polling-period, threshold or both*/
+void TxPortMonOrch::doTask(Consumer& consumer){
+
+	SWSS_LOG_ENTER();
+	SWSS_LOG_INFO("TxPortMonOrch::doTask Config Update\n");
+
+	int return_status = 0;
+
+	if (!gPortsOrch->allPortsReady())
+	{
+		SWSS_LOG_INFO("TxPortMonOrch::doTask Ports not ready yet \n");
+		return;
+	}
+
+	auto it = consumer.m_toSync.begin();
+	while (it != consumer.m_toSync.end())
+	{
+		KeyOpFieldsValuesTuple t = it->second;
+
+		string key = kfvKey(t);
+	    string op = kfvOp(t);
+		vector<FieldValueTuple> fvs = kfvFieldsValues(t);
+
+		SWSS_LOG_INFO("TxPortMonOrch::doTask Key: %s, Operation: \n", key.c_str());
+
+		if (key == TXPORTMONORCH_KEY_CFG_PERIOD){
+
+			if (op == SET_COMMAND){
+				return_status = handlePeriodUpdate(fvs);
+			}
+			else
+			{
+			    SWSS_LOG_ERROR("TxPortMonOrch::doTask Unknown Operation %s for Pooling Period Config Update for key %s\n", op.c_str(), key.c_str());
+			}
+		}
+		// TODO : Check if the key is a valid alias of interface
+		else {
+			 if (op == SET_COMMAND)
+			 {
+				//fetch the value which reprsents threshold
+				return_status = handleThresholdUpdate(key, fvs, false);
+			 }
+			else if (op == DEL_COMMAND)
+			{
+				//remove entry from state table and local map
+				return_status = handleThresholdUpdate(key, fvs, true);
+			}
+			else
+			{
+				SWSS_LOG_ERROR("TxPortMonOrch::doTask Unknown operation type %s when setting threshold\n", op.c_str());
+			}
+		}
+
+		if (return_status < 0){
+		     SWSS_LOG_ERROR("TxPortMonOrch::FAIL Not in the Correct State, error reported on port: %s\n", key.c_str());
+		}
+
+		consumer.m_toSync.erase(it++);
+    }
+}
+
+
+/* Returns 0 on success */
+int TxPortMonOrch::handlePeriodUpdate(const vector<FieldValueTuple>& data){
+
+
+	bool restart = false;
+	bool shutdown = false;
+
+	SWSS_LOG_ENTER();
+
+
+	//	if (data.size() > 1){
+	//		SWSS_LOG_INFO("TxPortMonOrch::handlePeriodUpdate Update Size > 1: Check With Redis-subscription mechanism inside SWSS");
+	//	}
+
+	//Only the latest update is bothered about
+	try {
+		FieldValueTuple payload = *data.rbegin();
+
+		if (fvField(payload) == TXPORTMONORCH_FIELD_CFG_PERIOD){
+
+			uint32_t periodToSet = static_cast<uint32_t>(stoul(fvValue(payload)));
+
+			if (periodToSet == 0){
+				shutdown = true;
+			}
+			else if(periodToSet != m_pollPeriod){
+				restart = true;
+				m_pollPeriod = periodToSet;
+			}
+			else{
+				// do nothing
+			}
+		}
+		else{
+			SWSS_LOG_ERROR("TxPortMonOrch::handlePeriodUpdate Unknown field type %s\n", fvField(payload).c_str());
+			return -1;
+		}
+
+		/* Shutdown clears complete state and application state */
+		if (shutdown){
+			m_pollTimer->stop(); // Stop the timer
+			for (auto port : m_TxErrorTable){
+				m_stateTxErrorTable->del(port.first); // Clear everything from the sSTATE_TX_ERROR_TABLE
+				SWSS_LOG_INFO("TxPortMonOrch::handlePeriodUpdate Everything cleared in state tx table for the port %s\n", port.first.c_str());
+			}
+			m_TxErrorTable.clear(); //Clean everything from Local Map
+			SWSS_LOG_INFO("TxPortMonOrch::handlePeriodUpdate Complete Application data has been cleared ");
+
+		}
+
+		if (restart){
+			this->startTimer(m_pollPeriod);
+			this->pollErrorStatistics(); // When restarted Update the current stats
+			SWSS_LOG_INFO("TxPortMonOrch::handlePeriodUpdate TX_ERR poll timer restarted with interval %d\n", m_pollPeriod);
+		}
+	}
+	catch (...){
+		SWSS_LOG_ERROR("TxPortMonOrch::handlePeriodUpdate Failed\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+
+/*
+ * Returns 0 on success
+ 	      -1 in something failed
+ 	       1 Invalid Parameters recieved in the config
+*/
+int TxPortMonOrch::handleThresholdUpdate(const string &port, const vector<FieldValueTuple>& data, bool clear){
+
+	try {
+		if (clear){
+			m_TxErrorTable.erase(port); //Create from Local Map
+			m_stateTxErrorTable->del(port); // Clear from State Table
+			SWSS_LOG_INFO("TxPortMonOrch::handleThresholdUpdate threshold cleared for port %s\n", port.c_str());
+		}
+		else{
+			// Only the latest update is considered.
+			auto payload = *data.begin();
+
+			if (fvField(payload) == TXPORTMONORCH_FIELD_CFG_THRESHOLD){
+
+				sai_object_id_t port_id;
+				uint64_t existingCount;
+
+				// Port is added for the first time
+				if (m_TxErrorTable.find(port) == m_TxErrorTable.end()){
+					Port saiport;
+					if (gPortsOrch->getPort(port, saiport))
+					{
+						port_id = saiport.m_port_id;
+					}
+					else{
+						SWSS_LOG_ERROR("TxPortMonOrch::handleThresholdUpdate getPort id failed for port %s", port.c_str());
+						throw 20;
+					}
+				}
+				else{
+					// if threshold already same, don't do anything
+					if (txPortThreshold(m_TxErrorTable[port]) == static_cast<uint64_t>(stoull(fvValue(payload)))) {
+						SWSS_LOG_INFO("TxPortMonOrch::handleThresholdUpdate Parameter has not changed for threshold on port %s, in recent config update", port.c_str());
+						return 0;
+					}
+
+					port_id = txPortId(m_TxErrorTable[port]);
+				}
+
+				if (fetchTxErrorStats(port, existingCount, port_id)){
+					SWSS_LOG_ERROR("TxPortMonOrch::handleThresholdUpdate fetching error count from CounterDB failed for port %s", port.c_str());
+					throw 20;
+				}
+
+				// Fill in the states
+				TxErrorStats fields;
+				txPortState(fields) = static_cast<int8_t>(TXSTATE_OK);
+				txPortId(fields) = port_id;
+				txPortErrCount(fields) = existingCount;
+				txPortThreshold(fields) = static_cast<uint64_t>(stoull(fvValue(payload)));
+
+				if (m_TxErrorTable.find(port) == m_TxErrorTable.end()){
+				    m_TxErrorTable.emplace(port, fields);
+				}
+				else{
+				    m_TxErrorTable[port] = fields;
+				}
+
+				SWSS_LOG_INFO("TxPortMonOrch::handleThresholdUpdate Details added/Updated for port %s, Err_count %ld, Threshold_set %ld", port.c_str(), txPortErrCount(fields), txPortThreshold(fields));
+
+				this->writeToStateDb(port);
+			}
+			else
+			{
+				SWSS_LOG_ERROR("TxPortMonOrch::handleThresholdUpdate Unknown field type %s when handle threshold for %s\n",
+							   fvField(payload).c_str(), port.c_str());
+				return 1;
+			}
+		}
+	}
+	catch (...){
+		SWSS_LOG_ERROR("TxPortMonOrch::handleThresholdUpdate failed for port %s\n", port.c_str());
+		return -1;
+	}
+
+	return 0;
+}
+
+int TxPortMonOrch::fetchTxErrorStats(const string& port, uint64_t& currentCount, const sai_object_id_t& port_id){
+
+	std::string value;
+
+     if (m_countersTable->hget(sai_serialize_object_id(port_id), TXPORTMONORCH_EGRESS_ERR_ID, value)){
+         currentCount = static_cast<uint64_t>(stoull(value));
+         SWSS_LOG_INFO("TxPortMonOrch::fetchTxErrorStats TX_ERR_POLL: port: %s (%s), found %ld %s\n", port.c_str(), sai_serialize_object_id(port_id).c_str(), currentCount, value.c_str());
+     }
+     else{
+         SWSS_LOG_INFO("TxPortMonOrch::fetchTxErrorStats failed to fetch statistics for port %s id: %s \n", port.c_str(), sai_serialize_object_id(port_id).c_str());
+         return -1;
+     }
+
+	 return 0;
+}
+
+int TxPortMonOrch::writeToStateDb(const string& port){
+
+	if (m_TxErrorTable.find(port) == m_TxErrorTable.end()){
+		SWSS_LOG_INFO("TxPortMonOrch: flush invoked for port %s, which doesn't have an entry in Local Map", port.c_str());
+		return -1;
+	}
+
+	auto& fields = m_TxErrorTable[port];
+
+	vector<FieldValueTuple> fvs;
+
+	fvs.emplace_back(TXPORTMONORCH_APPL_STATUS, TxStatusName[txPortState(fields)]);
+	fvs.emplace_back(TXPORTMONORCH_APPL_TIMESTAMP, currentDateTime());
+	fvs.emplace_back(TXPORTMONORCH_APPL_SAIPORTID, sai_serialize_object_id(txPortId(fields)));
+	fvs.emplace_back("tx_error_threshold", to_string(txPortThreshold(fields)));
+
+	m_stateTxErrorTable->set(port, fvs);
+
+	m_stateTxErrorTable->flush();
+
+	SWSS_LOG_INFO("TxPortMonOrch Flushed to State DB port %s", port.c_str());
+
+	return 0;
+}
+
+

--- a/orchagent/txportmonorch.cpp
+++ b/orchagent/txportmonorch.cpp
@@ -36,7 +36,7 @@ TxPortMonOrch::TxPortMonOrch(TableConnector confDbConnector,
 
 		SWSS_LOG_ENTER();
 
-		swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_INFO);
+//		swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_INFO);
 
 
 		m_stateTxErrorTable = make_shared<Table>(stateDbConnector.first, stateDbConnector.second);

--- a/orchagent/txportmonorch.h
+++ b/orchagent/txportmonorch.h
@@ -1,0 +1,109 @@
+#ifndef SWSS_TXMONORCH_H
+#define SWSS_TXMONORCH_H
+
+#include <memory>
+#include <unordered_map>
+#include <tuple>
+#include <inttypes.h>
+#include <string>
+#include <utility>
+#include <exception>
+
+#include <inttypes.h>
+
+#include "orch.h"
+#include "table.h"
+#include "select.h"
+#include "timer.h"
+#include "portsorch.h"
+
+#include "port.h"
+#include "logger.h"
+#include "sai_serialize.h"
+//#include "orchdaemon.h"
+
+
+
+/* Field Definitions */
+#define TXPORTMONORCH_FIELD_CFG_PERIOD "tx_error_check_period"
+#define TXPORTMONORCH_FIELD_CFG_THRESHOLD "tx_error_threshold"
+#define TXPORTMONORCH_FIELD_STATE_TX_STATE "tx_status"
+
+/* Table Names defined in Schema.h */
+#define TXPORTMONORCH_CFG_TX_ERROR_TABLE "TX_ERR_CFG"
+#define TXPORTMONORCH_STATE_TX_ERROR_TABLE  "TX_ERR_STATE"
+
+/* Table to retrieve Counter Statistics */
+#define TXPORTMONORCH_COUNTERTABLE  "COUNTERS"
+
+/* aliases for application state stored in-memory of the class */
+#define TXPORTMONORCH_APPL_STATUS  "tx_error_stats"
+#define TXPORTMONORCH_APPL_TIMESTAMP  "tx_error_verified_latest_by"
+#define TXPORTMONORCH_APPL_SAIPORTID  "tx_error_portid"
+/* KEY */
+#define TXPORTMONORCH_KEY_CFG_PERIOD  "GLOBAL_PERIOD"
+
+/* Egress Error Identifier for a port */
+#define TXPORTMONORCH_EGRESS_ERR_ID  "SAI_PORT_STAT_IF_OUT_ERRORS"
+
+#define TXPORTMONORCH_SEL_TIMER     "TX_ERR_COUNTERS_POLL"
+
+/* Helper Functions */
+#define txPortState std::get<0>
+#define txPortId std::get<1>
+#define txPortErrCount std::get<2>
+#define txPortThreshold std::get<3>
+
+
+/* Data Structures which represent TxError Stats */
+using TxErrorStats = std::tuple<int8_t, sai_object_id_t, uint64_t, uint64_t>;
+using TxErrorStatMap = std::unordered_map<std::string, TxErrorStats> ;
+
+// Get current date/time, format is YYYY-MM-DD.HH:mm:ss
+const std::string currentDateTime();
+
+/* In-Memory Application data helper functions */
+// Constexpr int8_t& m_portID(TxErrorStats& txStat) {return std::get<0>(txStat);}
+
+class TxPortMonOrch : public Orch
+{
+    public:
+
+        TxPortMonOrch(TableConnector confDbConnector, TableConnector stateDbConnector);
+
+        ~TxPortMonOrch();
+
+        void doTask(Consumer& consumer);
+        void doTask(SelectableTimer &timer);
+
+    private:
+        std::shared_ptr<Table> m_stateTxErrorTable;
+        std::shared_ptr<Table> m_countersTable;
+
+        std::shared_ptr<DBConnector> m_countersDb;
+
+        uint32_t m_pollPeriod;
+
+
+        SelectableTimer* m_pollTimer;
+
+        /* In-Memory table to keep track of Error Stats */
+        TxErrorStatMap m_TxErrorTable;
+
+        void startTimer(uint32_t interval);
+        int handlePeriodUpdate(const vector<FieldValueTuple>& data);
+        int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
+        int pollOnePortErrorStatistics(const string &port, TxErrorStats &stat);
+        void pollErrorStatistics();
+
+        /* fetch Error Stats from Counter DB */
+        /* Returns 0 on success */
+        int fetchTxErrorStats(const string& port, uint64_t& currentCount, const sai_object_id_t& port_id);
+
+        /* Returns 0 on success.... Uses the state from TxErrorStatMap */
+        int writeToStateDb(const string& port);
+};
+
+#endif
+
+

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -61,7 +61,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/chassisorch.cpp \
                 $(top_srcdir)/orchagent/sfloworch.cpp \
                 $(top_srcdir)/orchagent/debugcounterorch.cpp \
-                $(top_srcdir)/orchagent/natorch.cpp 
+                $(top_srcdir)/orchagent/natorch.cpp \
+		$(top_srcdir)/orchagent/txportmonorch.cpp 
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added implementation for Tx Port Monitoring feature.

**Why I did it**
To Complete Lab-5 as a part of new employee training

**How I verified it**
Manual testing using CLI commands, which are written in sonic-utilities repo. Used redis-cle & Counter DB to simulate  Tx Error counts 

**Details if related**
* TxPortMon class inherits from Orch
* Selectable Timer is used to invoke the class at the end of pooling period
* Changes in Config are listed to for <interface,threshold> & pooling changes
* An internal Hash Map is used to Store the State Information for interfaces
* State Information and other data in periodically pushed to State DB
 