### PR TITLE
[CoppOrch]: Stale Policer SAI Object Creation Fixed

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -379,7 +379,10 @@ bool CoppOrch::createPolicer(string trap_group_name, vector<sai_attribute_t> &po
     sai_status = sai_hostif_api->set_hostif_trap_group_attribute(m_trap_group_map[trap_group_name], &attr);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to bind policer to trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
+        SWSS_LOG_ERROR("Failed to bind policer to trap group %s, rc=%d and thus deleting the policer object %" PRIx64 "", trap_group_name.c_str(), sai_status, policer_id);
+	if (sai_policer_api->remove_policer(policer_id) != SAI_STATUS_SUCCESS){
+            SWSS_LOG_ERROR("Failed to remove the stale entry of the policer %" PRIx64 "", policer_id);
+        }
         return false;
     }
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added a fix to delete the Stale Policer SAI Object . 

**Why I did it**
When the Policer binding fails with the Trap Group, the policer object created originally persists even when the trap group is deleted by the user. So, in a way, this kind off is a memory leak. 

**How I verified it**

**Details if related**


Signed-off-by: Vivek Reddy Karri <vivekreddykarri98@gmail.com>
