### PR TITLE
[SflowMgr] SamplingRate Update by Speed Change Fixed

### DIFF
--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -77,12 +77,10 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
         if (op == SET_COMMAND)
         {
             SflowPortInfo port_info;
-            bool new_port = false;
 
             auto sflowPortConf = m_sflowPortConfMap.find(key);
             if (sflowPortConf == m_sflowPortConfMap.end())
             {
-                new_port = true;
                 port_info.local_conf = false;
                 port_info.speed = SFLOW_ERROR_SPEED_STR;
                 port_info.rate = "";
@@ -97,9 +95,10 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
                 }
             }
 
-            if (new_port)
+            if (m_gEnable)
             {
-                if (m_gEnable && m_intfAllConf)
+                // If the Local Conf is already present, dont't override it even though the speed is changed
+                if (!m_sflowPortConfMap[key].local_conf && m_intfAllConf)
                 {
                     vector<FieldValueTuple> fvs;
                     sflowGetGlobalInfo(fvs, m_sflowPortConfMap[key].speed);
@@ -171,7 +170,7 @@ void SflowMgr::sflowGetGlobalInfo(vector<FieldValueTuple> &fvs, string speed)
     FieldValueTuple fv1("admin_state", "up");
     fvs.push_back(fv1);
 
-    if (speed != SFLOW_ERROR_SPEED_STR)
+    if (speed != SFLOW_ERROR_SPEED_STR && sflowSpeedRateInitMap.find(speed) != sflowSpeedRateInitMap.end())
     {
         rate = sflowSpeedRateInitMap[speed];
     }

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -131,6 +131,46 @@ class TestSflow:
 
         expected_fields = {"SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE": rate}
         self.adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", sample_session, expected_fields)
+    
+    def test_SamplingRatePortCfgUpdate(self, dvs, testlog):
+        '''
+        This test checks if the SflowMgr updates the sampling rate 
+        1) When the Speed is Updated on the port and no local configuration has been given on the port
+        Eg:
+        config sflow enable
+        config interface Ethernet0 speed 25000  (Original Speed for Ethernet0 is 100G)
+        show sflow interface | grep Ethernet0   (Should see a sampling rate of 25000 not 100000)
+        '''
+        self.setup_sflow(dvs)
+        appldb = dvs.get_app_db()
+        #dvs.runcmd("portconfig -p {} -s {}".format("Ethernet0", "25000"))
+        self.cdb.update_entry("PORT", "Ethernet0", {'speed' : "25000"})
+        expected_fields = {"sample_rate": self.speed_rate_table["25000"]}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+
+    
+    def test_SamplingRateManualUpdate(self, dvs, testlog):
+        '''  
+        This test checks if the SflowMgr updates the sampling rate 
+        1) When the Cfg Sflow Table is updated with sampling rate by the user, this rate should not be impacted by Port Speed Changes
+        Eg:
+        config sflow enable
+        config sflow interface sample-rate Ethernet4 256
+        config interface Ethernet0 speed 25000  (Original Speed for Ethernet0 is 100G)
+        show sflow interface | grep Ethernet0   (Should see  a sampling rate of 256 not 100000 or 25000
+        '''
+        self.setup_sflow(dvs)
+        appldb = dvs.get_app_db()
+        
+        session_params = {"admin_state": "up", "sample_rate": "256"}
+        self.cdb.create_entry("SFLOW_SESSION", "Ethernet4", session_params)
+        self.cdb.wait_for_field_match("SFLOW_SESSION", "Ethernet4", session_params)
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", {"sample_rate": "256"})
+        
+        self.cdb.update_entry("PORT", "Ethernet4", {'speed' : "25000"})
+        time.sleep(0.01)
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", {"sample_rate": "256"})
+    
 
     def test_Teardown(self, dvs, testlog):
         self.setup_sflow(dvs)

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -140,8 +140,8 @@ class TestSflow:
         1) When the Speed is Updated on the port and no local configuration has been given on the port
         Eg:
         config sflow enable
-        config interface Ethernet0 speed 25000  (Original Speed for Ethernet0 is 100G)
-        show sflow interface | grep Ethernet0   (Should see a sampling rate of 25000 not 100000)
+        config interface speed Ethernet0  25000  (Let's suppose Original Speed for Ethernet0 is 100G)
+        show sflow interface | grep Ethernet0    (Should see a sampling rate of 25000 not 100000)
         '''
         self.setup_sflow(dvs)
         appldb = dvs.get_app_db()
@@ -170,7 +170,9 @@ class TestSflow:
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", {"sample_rate": "256"})
         
         self.cdb.update_entry("PORT", "Ethernet4", {'speed' : "25000"})
-        time.sleep(0.01)
+        # The Check here is about the original value not getting changed. 
+        # If some bug was to appear, let's give it some time to get noticed
+        time.sleep(1) 
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", {"sample_rate": "256"})
     
 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,3 +1,5 @@
+import time
+
 class TestSflow:
     speed_rate_table = {
         "400000": "400000",


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1) Updated the SflowMgr::sflowUpdatePortInfo method to be active for speed change notifications .
2) Added two new Unit Tests covering these use cases

**Why I did it**

#### Run This:
 ```
config sflow enable
config interface speed Ethernet0  25000  (Let's suppose Original Speed for Ethernet0 is 100G)
show sflow interface | grep Ethernet0  

Expected:
Should see a sampling rate of 25000 

Observed:
Sampling rate is unaffected by speed change i.e is still 100000
```

**How I verified it**

1) All the Unit Tests passed
2) Manually Verified using the the steps given above

**Details if related**
