### PR TITLE
[tlm_teamd] get_dumps log because of a redundant keyspace notif handled

### DIFF
--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -19,8 +19,8 @@ public:
     bool remove_lag(const std::string & lag_name);
     void process_add_queue();
     // Retry logic added to prevent incorrect error reporting in dump API's
-    TeamdCtlDump get_dump(const std::string & lag_name, bool to_retry);
-    TeamdCtlDumps get_dumps(bool to_retry);
+    TeamdCtlDump get_dump(const std::string & lag_name, int num_retry);
+    TeamdCtlDumps get_dumps(int num_retry);
 
 private:
     bool has_key(const std::string & lag_name) const;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**



**Why I did it**

`https://github.com/Azure/sonic-swss/pull/1629` This PR originally fixed the spurious get_dumps log seen during select timeout . The same log has reappeared again, this time because of a redundant key-space notification seen when a config port channel delete is given.

Analysis

```
root@sonic:/home/admin# sudo config portchannel del PortChannel1111

admin@sonic:~$ redis-cli psubscribe "__keyspace@6__:*LAG*"
1) "pmessage"
2) "__keyspace@6__:*LAG*"
3) "__keyspace@6__:LAG_TABLE|PortChannel1111"
4) "hset"

Message Contents: 
{{first = "admin_status", second = "down"}, 
{first = "oper_status", second = "down"}, 
{first = "mtu", second = "9100"}, 
{first = "state", second = "ok"}}}}

An Example kvpairs when an actual SET event is seen
{{first = "admin_status", second = "up"}, 
{first = "oper_status", second = "down"}, 
{first = "mtu", second = "9100"}, 
{first = "state", second = "ok"}, 
{first = "team_device.ifinfo.ifindex", second = "175"}, 
{first = "setup.kernel_team_mode_name", second = "loadbalance"}, 
{first = "runner.active", second = "true"}, 
{first = "runner.fast_rate", second = "false"}, 
{first = "runner.fallback", second = "false"}, {first = "setup.pid", second = "1335"},
{first = "team_device.ifinfo.dev_addr", second = "1c:34:da:1c:a0:00"}

1) "pmessage"
2) "__keyspace@6__:*LAG*"
3) "__keyspace@6__:LAG_TABLE|PortChannel1111"
4) "del"
```
This extra notification is probably because there are two netlink msgs generated when the portchannel is deleted and teamsyncd is writing them to state_db, causing two notifications 

This is causing an error log seen for tlm_teamd
```
Jan 21 04:19:09.049965 sonic ERR teamd#tlm_teamd: :- get_dump: Can't get dump for LAG 'PortChannel1111'. Skipping
Jan 21 04:19:09.051633 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel1111' has been removed.
Jan 21 04:19:09.802348 sonic INFO teamd#supervisord 2022-01-21 04:19:09,801 INFO reaped unknown pid 649 (exit status 0)
Jan 21 04:19:09.843253 sonic NOTICE teamd#teammgrd: :- removeLag: Stop port channel PortChannel1111
```


**How I verified it**

**Details if related**
