### PR TITLE
[PFC_WD] [202012] Avoid applying ZeroBuffer Profiles to ingress PG when a PFC storm is detected

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1066,7 +1066,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     for (string port_name : port_names)
     {
         Port port;
-        bool portUpdated = false;
         SWSS_LOG_DEBUG("processing port:%s", port_name.c_str());
         if (!gPortsOrch->getPort(port_name, port))
         {
@@ -1080,12 +1079,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
             {
                 SWSS_LOG_ERROR("Invalid pg index specified:%zd", ind);
                 return task_process_status::task_invalid_entry;
-            }
-            if (port.m_priority_group_lock[ind])
-            {
-                SWSS_LOG_WARN("Priority group %zd on port %s is locked, pending profile 0x%" PRIx64 " until unlocked", ind, port_name.c_str(), sai_buffer_profile);
-                portUpdated = true;
-                port.m_priority_group_pending_profile[ind] = sai_buffer_profile;
             }
             else
             {
@@ -1106,10 +1099,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                     }
                 }
             }
-        }
-        if (portUpdated)
-        {
-            gPortsOrch->setPort(port_name, port);
         }
     }
 

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -125,39 +125,36 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
 
     private:
         /*
-         * Sets lock bits on port's priority group and queue
-         * to protect them from being changed by other Orch's
-         */
-        void setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const;
+         * Sets lock bits on port's queue
+         * to protect it from being changed by other Orch's
+        */
+        void setQueueLockFlag(Port& port, bool isLocked) const;
 
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile
         {
             public:
                 ~ZeroBufferProfile(void);
-                static sai_object_id_t getZeroBufferProfile(bool ingress);
+                static sai_object_id_t getZeroBufferProfile();
 
             private:
                 ZeroBufferProfile(void);
                 static ZeroBufferProfile &getInstance(void);
-                void createZeroBufferProfile(bool ingress);
-                void destroyZeroBufferProfile(bool ingress);
+                void createZeroBufferProfile();
+                void destroyZeroBufferProfile();
 
-                sai_object_id_t& getProfile(bool ingress)
+                sai_object_id_t& getProfile()
                 {
-                    return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
+                    return m_zeroEgressBufferProfile;
                 }
 
-                sai_object_id_t& getPool(bool ingress);
+                sai_object_id_t& getPool();
 
-                sai_object_id_t m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
-                sai_object_id_t m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
         };
 
         sai_object_id_t m_originalQueueBufferProfile = SAI_NULL_OBJECT_ID;
-        sai_object_id_t m_originalPgBufferProfile = SAI_NULL_OBJECT_ID;
 };
 
 // PFC queue that implements drop action by draining queue via SAI

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -114,15 +114,13 @@ public:
     uint32_t  m_maximum_headroom = 0;
 
     /*
-     * Following two bit vectors are used to lock
-     * the PG/queue from being changed in BufferOrch.
+     * Following bit vector is used to lock
+     * the queue from being changed in BufferOrch.
      * The use case scenario is when PfcWdZeroBufferHandler
-     * sets zero buffer profile it should protect PG/queue
+     * sets zero buffer profile it should protect queue
      * from being overwritten in BufferOrch.
      */
     std::vector<bool> m_queue_lock;
-    std::vector<bool> m_priority_group_lock;
-    std::vector<sai_object_id_t> m_priority_group_pending_profile;
 
     std::unordered_set<sai_object_id_t> m_ingress_acl_tables_uset;
     std::unordered_set<sai_object_id_t> m_egress_acl_tables_uset;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3583,8 +3583,6 @@ void PortsOrch::initializePriorityGroups(Port &port)
     SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
 
     port.m_priority_group_ids.resize(attr.value.u32);
-    port.m_priority_group_lock.resize(attr.value.u32);
-    port.m_priority_group_pending_profile.resize(attr.value.u32);
 
     if (attr.value.u32 == 0)
     {

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -43,26 +43,6 @@ namespace portsorch_test
         }
     }
 
-    sai_status_t _ut_stub_sai_get_ingress_priority_group_attribute(
-        _In_ sai_object_id_t ingress_priority_group_id,
-        _In_ uint32_t attr_count,
-        _Inout_ sai_attribute_t *attr_list)
-    {
-        if (attr_count == 1 && attr_list[0].id == SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE)
-        {
-            auto &typemapPg = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_PG_TABLE_NAME]);
-            auto &profileName = typemapPg["Ethernet0:3-4"].m_objsReferencingByMe["profile"];
-            auto profileNameVec = tokenize(profileName, ':');
-            auto &typemapProfile = (*gBufferOrch->m_buffer_type_maps[APP_BUFFER_PROFILE_TABLE_NAME]);
-            attr_list[0].value.oid = typemapProfile[profileNameVec[1]].m_saiObjectId;
-            return SAI_STATUS_SUCCESS;
-        }
-        else
-        {
-            return pold_sai_buffer_api->get_ingress_priority_group_attribute(ingress_priority_group_id, attr_count, attr_list);
-        }
-    }
-
     int _sai_create_buffer_pool_count = 0;
     sai_status_t _ut_stub_sai_create_buffer_pool(
         _Out_ sai_object_id_t *buffer_pool_id,
@@ -92,7 +72,6 @@ namespace portsorch_test
         pold_sai_buffer_api = sai_buffer_api;
         ut_sai_buffer_api.create_buffer_pool = _ut_stub_sai_create_buffer_pool;
         ut_sai_buffer_api.remove_buffer_pool = _ut_stub_sai_remove_buffer_pool;
-        ut_sai_buffer_api.get_ingress_priority_group_attribute = _ut_stub_sai_get_ingress_priority_group_attribute;
         sai_buffer_api = &ut_sai_buffer_api;
 
         ut_sai_queue_api = *sai_queue_api;
@@ -110,9 +89,7 @@ namespace portsorch_test
     void clear_pfcwd_zero_buffer_handler()
     {
         auto &zeroProfile = PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance();        
-        zeroProfile.m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
         zeroProfile.m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
-        zeroProfile.m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
         zeroProfile.m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
     }
 
@@ -426,11 +403,10 @@ namespace portsorch_test
         ASSERT_TRUE(ts.empty());
     }
 
-    TEST_F(PortsOrchTest, PfcZeroBufferHandlerLocksPortPgAndQueue)
+    TEST_F(PortsOrchTest, PfcZeroBufferHandlerLocksQueue)
     {
         _hook_sai_buffer_and_queue_api();
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
-        Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
         Table profileTable = Table(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
         Table poolTable = Table(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
         Table queueTable = Table(m_app_db.get(), APP_BUFFER_QUEUE_TABLE_NAME);
@@ -474,13 +450,6 @@ namespace portsorch_test
 
         // Create test buffer pool
         poolTable.set(
-            "ingress_pool",
-            {
-                { "type", "ingress" },
-                { "mode", "dynamic" },
-                { "size", "4200000" },
-            });
-        poolTable.set(
             "egress_pool",
             {
                 { "type", "egress" },
@@ -489,16 +458,9 @@ namespace portsorch_test
             });
 
         // Create test buffer profile
-        profileTable.set("test_profile", { { "pool", "[BUFFER_POOL_TABLE:ingress_pool]" },
-                                           { "xon", "14832" },
-                                           { "xoff", "14832" },
+        profileTable.set("test_profile", { { "pool", "[BUFFER_POOL_TABLE:egress_pool]" },
                                            { "size", "35000" },
                                            { "dynamic_th", "0" } });
-        profileTable.set("ingress_profile", { { "pool", "[BUFFER_POOL_TABLE:ingress_pool]" },
-                                              { "xon", "14832" },
-                                              { "xoff", "14832" },
-                                              { "size", "35000" },
-                                              { "dynamic_th", "0" } });
         profileTable.set("egress_profile", { { "pool", "[BUFFER_POOL_TABLE:egress_pool]" },
                                              { "size", "0" },
                                              { "dynamic_th", "0" } });
@@ -508,10 +470,8 @@ namespace portsorch_test
         {
             std::ostringstream oss;
             oss << it.first << ":3-4";
-            pgTable.set(oss.str(), { { "profile", "[BUFFER_PROFILE_TABLE:ingress_profile]" } });
             queueTable.set(oss.str(), { {"profile", "[BUFFER_PROFILE_TABLE:egress_profile]" } });
         }
-        gBufferOrch->addExistingData(&pgTable);
         gBufferOrch->addExistingData(&poolTable);
         gBufferOrch->addExistingData(&profileTable);
         gBufferOrch->addExistingData(&queueTable);
@@ -523,69 +483,31 @@ namespace portsorch_test
         auto current_create_buffer_pool_count = _sai_create_buffer_pool_count;
         auto dropHandler = make_unique<PfcWdZeroBufferHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
 
-        current_create_buffer_pool_count += 2;
+        current_create_buffer_pool_count += 1;
         ASSERT_TRUE(current_create_buffer_pool_count == _sai_create_buffer_pool_count);
-        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(true) == gBufferOrch->m_ingressZeroBufferPool);
-        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(false) == gBufferOrch->m_egressZeroBufferPool);
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool() == gBufferOrch->m_egressZeroBufferPool);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 0);
         ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
 
         std::deque<KeyOpFieldsValuesTuple> entries;
         entries.push_back({"Ethernet0:3-4", "SET", {{ "profile", "[BUFFER_PROFILE_TABLE:test_profile]"}}});
-        auto pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
-        pgConsumer->addToSync(entries);
+        auto queueConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_QUEUE_TABLE_NAME));
+        queueConsumer->addToSync(entries);
         entries.clear();
         static_cast<Orch *>(gBufferOrch)->doTask();
 
-        // Port should have been updated by BufferOrch->doTask
-        gPortsOrch->getPort("Ethernet0", port);
-        auto profile_id = (*BufferOrch::m_buffer_type_maps["BUFFER_PROFILE_TABLE"])[string("test_profile")].m_saiObjectId;
-        ASSERT_TRUE(profile_id != SAI_NULL_OBJECT_ID);
-        ASSERT_TRUE(port.m_priority_group_pending_profile[3] == profile_id);
-        ASSERT_TRUE(port.m_priority_group_pending_profile[4] == SAI_NULL_OBJECT_ID);
-
-        pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
-        pgConsumer->dumpPendingTasks(ts);
-        ASSERT_TRUE(ts.empty()); // PG is stored in m_priority_group_pending_profile
+        queueConsumer->dumpPendingTasks(ts);
+        ASSERT_FALSE(ts.empty()); // Queue is skipped
         ts.clear();
-
-        // Create a zero buffer pool after PFC storm
-        entries.push_back({"ingress_zero_pool", "SET", {{ "type", "ingress" },
-                                                        { "mode", "static" },
-                                                        { "size", "0" }}});
-        auto poolConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_POOL_TABLE_NAME));
-        poolConsumer->addToSync(entries);
-        entries.clear();
-        static_cast<Orch *>(gBufferOrch)->doTask();
-        // Reference increased
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 2);
-        // Didn't create buffer pool again
-        ASSERT_TRUE(_sai_create_buffer_pool_count == current_create_buffer_pool_count);
-
-        entries.push_back({"ingress_zero_pool", "DEL", {}});
-        poolConsumer->addToSync(entries);
-        entries.clear();
-        auto current_remove_buffer_pool_count = _sai_remove_buffer_pool_count;
-        static_cast<Orch *>(gBufferOrch)->doTask();
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
-        ASSERT_TRUE(_sai_remove_buffer_pool_count == current_remove_buffer_pool_count);
 
         // release zero buffer drop handler
         dropHandler.reset();
 
-        // re-fetch the port
-        gPortsOrch->getPort("Ethernet0", port);
-
-        // pending profile should be cleared
-        ASSERT_TRUE(port.m_priority_group_pending_profile[3] == SAI_NULL_OBJECT_ID);
-        ASSERT_TRUE(port.m_priority_group_pending_profile[4] == SAI_NULL_OBJECT_ID);
-
-        // process PGs
+        // process queue
         static_cast<Orch *>(gBufferOrch)->doTask();
 
-        pgConsumer = static_cast<Consumer*>(gBufferOrch->getExecutor(APP_BUFFER_PG_TABLE_NAME));
-        pgConsumer->dumpPendingTasks(ts);
-        ASSERT_TRUE(ts.empty()); // PG should be processed now
+        queueConsumer->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty()); // queue should be processed now
         ts.clear();
         clear_pfcwd_zero_buffer_handler();
         _unhook_sai_buffer_and_queue_api();
@@ -650,9 +572,9 @@ namespace portsorch_test
                           { "mode", "dynamic" },
                           { "size", "4200000" },
                       });
-        poolTable.set("ingress_zero_pool",
+        poolTable.set("egress_zero_pool",
                       {
-                          { "type", "ingress" },
+                          { "type", "egress" },
                           { "mode", "static" },
                           { "size", "0" }
                       });
@@ -692,32 +614,40 @@ namespace portsorch_test
         static_cast<Orch *>(gBufferOrch)->doTask();
 
         ASSERT_TRUE(current_create_buffer_pool_count == _sai_create_buffer_pool_count);
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
-        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 0);
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroBufferPool != SAI_NULL_OBJECT_ID);
-        ASSERT_TRUE(gBufferOrch->m_egressZeroBufferPool == SAI_NULL_OBJECT_ID);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 0);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroBufferPool == SAI_NULL_OBJECT_ID);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroBufferPool != SAI_NULL_OBJECT_ID);
 
         auto countersTable = make_shared<Table>(m_counters_db.get(), COUNTERS_TABLE);
         auto dropHandler = make_unique<PfcWdZeroBufferHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
 
-        current_create_buffer_pool_count++; // Increased for egress zero pool
         ASSERT_TRUE(current_create_buffer_pool_count == _sai_create_buffer_pool_count);
-        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(true) == gBufferOrch->m_ingressZeroBufferPool);
-        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool(false) == gBufferOrch->m_egressZeroBufferPool);
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 2);
-        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
+        ASSERT_TRUE(PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().getPool() == gBufferOrch->m_egressZeroBufferPool);
+        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 0);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 2);
 
         std::deque<KeyOpFieldsValuesTuple> entries;
-        entries.push_back({"ingress_zero_pool", "DEL", {}});
+        entries.push_back({"egress_zero_pool", "DEL", {}});
         poolConsumer->addToSync(entries);
         entries.clear();
         auto current_remove_buffer_pool_count = _sai_remove_buffer_pool_count;
         static_cast<Orch *>(gBufferOrch)->doTask();
-        ASSERT_TRUE(gBufferOrch->m_ingressZeroPoolRefCount == 1);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 1);
         ASSERT_TRUE(_sai_remove_buffer_pool_count == current_remove_buffer_pool_count);
 
         // release zero buffer drop handler
         dropHandler.reset();
+
+        current_remove_buffer_pool_count = _sai_remove_buffer_pool_count;
+
+        // Destory the Singleton Class
+        PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance().destroyZeroBufferProfile();
+
+        ASSERT_TRUE(_sai_remove_buffer_pool_count == current_remove_buffer_pool_count + 1);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroPoolRefCount == 0);
+        ASSERT_TRUE(gBufferOrch->m_egressZeroBufferPool == SAI_NULL_OBJECT_ID);
+
         clear_pfcwd_zero_buffer_handler();
         _unhook_sai_buffer_and_queue_api();
     }


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Backport `https://github.com/vivekreddynv/sonic-swss/pull/11` to 202012 since direct cherry-pick is not possible.

Conflict was only in the portsorch_ut file where `[BUFFER_PROFILE_TABLE:test_profile]` was used as opposed to `test_profile` in master branch

**Why I did it**

**How I verified it**

**Details if related**
